### PR TITLE
Add MegaDetector-Classifier to ecosystem tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ PyTorch-Wildlife is part of the larger open-source ecosystem from the Microsoft 
 | [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | Animal detection in camera-trap imagery |
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — AI-enabled edge device |
 | [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic models for audio-based wildlife monitoring |
+| [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection for overhead and aerial imagery |
 | [SPARROW Studio](https://github.com/microsoft/Biodiversity/tree/main/SPARROW-Studio) | Desktop application for running all models with a graphical interface |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ PyTorch-Wildlife is one project in a larger open-source ecosystem from the AI fo
 | [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | Animal detection in camera-trap imagery |
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — AI-enabled edge device |
 | [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic models for audio-based wildlife monitoring |
+| [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection for overhead and aerial imagery |
 | [SPARROW Studio](https://github.com/microsoft/Biodiversity/tree/main/SPARROW-Studio) | Desktop application for running all models with a graphical interface |
 


### PR DESCRIPTION
## Summary

- Adds \`microsoft/MegaDetector-Classifier\` to all ecosystem tables (README.md and docs/index.md) — the new standalone repo for camera-trap species classification fine-tuning

## Test plan

- [ ] All ecosystem table rows render correctly in GitHub markdown preview
- [ ] \`MegaDetector-Classifier\` appears in README.md and docs/index.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)