### PR TITLE
rename: bongo_dev → sparrow-engine-dev references (sibling internal repo rename)

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1795,7 +1795,7 @@ sparrow/sparrow-engine/                     (image-pin contract)
 ### 15.2 Sparrow Studio Local — what's in flight
 
 ```
-Linux side (bongo_dev):                           Windows side (Sparrow Local):                                         
+Linux side (sparrow-engine-dev):                  Windows side (Sparrow Local):                                         
 ┌──────────────────────────────────┐              ┌──────────────────────────────────────┐                              
 │ libsparrow_engine.{so,dylib}     │              │ sparrow_engine.dll (build)           │                              
 │ sparrow_engine.h (cbindgen)      │              │ NativeMethods.g.cs                   │                              

--- a/sparrow-engine/scripts/build_and_tag_sparrow_engine.sh
+++ b/sparrow-engine/scripts/build_and_tag_sparrow_engine.sh
@@ -35,7 +35,7 @@ tag="${1:-}"
 [[ "$tag" =~ ^[A-Za-z0-9._-]+$ ]] || die "tag must match [A-Za-z0-9._-]+"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(git -C "$script_dir/../.." rev-parse --show-toplevel 2>/dev/null)" || die "script must run inside the bongo_dev repository"
+repo_root="$(git -C "$script_dir/../.." rev-parse --show-toplevel 2>/dev/null)" || die "script must run inside the sparrow-engine-dev repository"
 cd "$repo_root"
 
 ort_crate_version="$(extract_ort_crate_version)"

--- a/sparrow-engine/scripts/export_image_tarball.sh
+++ b/sparrow-engine/scripts/export_image_tarball.sh
@@ -38,7 +38,7 @@ tag="${1:-}"
 [[ "$tag" =~ ^[A-Za-z0-9._-]+$ ]] || die "tag must match [A-Za-z0-9._-]+"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(git -C "$script_dir/../.." rev-parse --show-toplevel 2>/dev/null)" || die "script must run inside the bongo_dev repository"
+repo_root="$(git -C "$script_dir/../.." rev-parse --show-toplevel 2>/dev/null)" || die "script must run inside the sparrow-engine-dev repository"
 cd "$repo_root"
 
 out_dir="${2:-$repo_root/sparrow-engine/dist/$tag}"

--- a/sparrow-engine/scripts/sparrow_contract_test.sh
+++ b/sparrow-engine/scripts/sparrow_contract_test.sh
@@ -343,7 +343,7 @@ main() {
     require_cmd python3
 
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    repo_root="$(git -C "$script_dir/../.." rev-parse --show-toplevel 2>/dev/null)" || die "script must run inside the bongo_dev repository"
+    repo_root="$(git -C "$script_dir/../.." rev-parse --show-toplevel 2>/dev/null)" || die "script must run inside the sparrow-engine-dev repository"
     cd "$repo_root"
 
     scratch_root="$repo_root/scratch"

--- a/sparrow-engine/sparrow-engine-gpu/tests/audio_e2e_parity.rs
+++ b/sparrow-engine/sparrow-engine-gpu/tests/audio_e2e_parity.rs
@@ -61,7 +61,7 @@
 //! Easiest: use the one-command runner
 //!
 //! ```bash
-//! ./scripts/run_audio_parity.sh    # from repo root (bongo_dev/)
+//! ./scripts/run_audio_parity.sh    # from repo root (sparrow-engine-dev/)
 //! ```
 //!
 //! Manual: from the sparrow-engine crate workspace:

--- a/sparrow-engine/sparrow-engine-gpu/tests/audio_e2e_parity_fp16.rs
+++ b/sparrow-engine/sparrow-engine-gpu/tests/audio_e2e_parity_fp16.rs
@@ -52,7 +52,7 @@
 //! Easiest: use the one-command runner
 //!
 //! ```bash
-//! ./scripts/run_audio_parity.sh    # from repo root (bongo_dev/)
+//! ./scripts/run_audio_parity.sh    # from repo root (sparrow-engine-dev/)
 //! ```
 //!
 //! Manual: from the sparrow-engine crate workspace:


### PR DESCRIPTION
Companion to https://github.com/zhmiao/sparrow-engine-dev/pull/1.

The internal dev-companion repo on the colleague's dev box was renamed `bongo_dev` → `sparrow-engine-dev` on 2026-05-22 to align with the `sparrow-x-dev ↔ sparrow-x/` convention (codified in the internal companion at `docs/design/architecture.md § Internal dev companion convention`).

## 6 files updated

- `docs/user-manual.md` §15.2 — diagram label `Linux side (bongo_dev)` → `Linux side (sparrow-engine-dev)` (reader-facing).
- `sparrow-engine/scripts/{build_and_tag_sparrow_engine,export_image_tarball,sparrow_contract_test}.sh` — die-on-missing-repo error string updated. Functional behavior unchanged (`git rev-parse --show-toplevel` doesn't care about the dir name).
- `sparrow-engine/sparrow-engine-gpu/tests/audio_e2e_parity{,_fp16}.rs` — comment example `from repo root (bongo_dev/)` → `sparrow-engine-dev/`.

## What changes

Only comments + error strings touched. No code, no tests, no behavior.

## Eventual PW rename

The eventual PW repo rename `microsoft/Pytorch-Wildlife` → `microsoft/sparrow-engine` is planned separately. This PR is a narrow follow-up to the internal-companion rename only.