### PR TITLE
docs: link MegaDetector documentation site from the repo table

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ PyTorch-Wildlife is part of the larger open-source ecosystem from the Microsoft 
 |---|---|
 | [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository — documentation hub for the AI for Good Lab's biodiversity work |
 | [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | This repo — the unified deep learning framework |
-| [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | Animal detection in camera-trap imagery |
+| [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | Animal detection in camera-trap imagery ([documentation](https://microsoft.github.io/MegaDetector/)) |
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — AI-enabled edge device |
 | [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic models for audio-based wildlife monitoring |
 | [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |


### PR DESCRIPTION
Adds a link to the **MegaDetector documentation site** (https://microsoft.github.io/MegaDetector/) next to the existing repo link in the ecosystem table, so readers reach the user guide directly and the docs site gains an inbound link from this repo.

Pairs with the MegaDetector docs/SEO refresh (microsoft/MegaDetector#21, now merged). Single-line, additive change.