### PR TITLE
docs(seo): PyTorch-Wildlife content depth + long-tail (framework/model-zoo lane)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,157 @@
+---
+title: "API Overview: PyTorch-Wildlife Framework"
+description: "How to use the PyTorch-Wildlife API: load detection and classification models, run single-image and batch inference, and export results, with runnable code."
+tags:
+  - PyTorch-Wildlife API
+  - wildlife AI framework
+  - conservation deep learning framework
+  - MegaDetector API
+  - batch inference
+---
+
+# API Overview
+
+PyTorch-Wildlife exposes a small, predictable surface. Once you know the shape of one model, you know them all: detectors and classifiers share the same single-image and batch entry points, and a common set of utilities turns their output into annotated images, crops, and JSON. This page is a guided tour of that API with code you can run, rather than a raw symbol dump. For the full catalog of loadable models, see the [Wildlife Model Zoo](model_zoo.md).
+
+## Package layout
+
+The framework groups everything under a few namespaces:
+
+```python
+from PytorchWildlife.models import detection as pw_detection
+from PytorchWildlife.models import classification as pw_classification
+from PytorchWildlife.models import bioacoustics as pw_bioacoustics
+from PytorchWildlife import utils as pw_utils
+```
+
+- `models.detection`: bounding-box and point detectors (MegaDetector, Deepfaune, HerdNet).
+- `models.classification`: species classifiers for crops or whole images.
+- `models.bioacoustics`: audio classifiers.
+- `utils`: output helpers for saving images, crops, JSON, and processing video.
+
+## Choosing a device
+
+Every model constructor takes a `device` argument. Use a CUDA GPU when one is available; otherwise the model runs on CPU:
+
+```python
+import torch
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+```
+
+If `torch.cuda.is_available()` returns `False` on a machine with an NVIDIA GPU, the [installation guide](installation.md#gpu-setup) explains how to install a CUDA-enabled PyTorch build.
+
+## Detection
+
+Detectors share two methods. `single_image_detection` runs one image; `batch_image_detection` runs a folder or dataloader. Both accept a `conf_thres` confidence threshold (default `0.2`).
+
+```python
+from PytorchWildlife.models import detection as pw_detection
+
+detector = pw_detection.MegaDetectorV6(device=DEVICE, version="MDV6-yolov10-e")
+
+# One image
+result = detector.single_image_detection("path/to/image.jpg", conf_thres=0.2)
+
+# A whole folder, batched
+results = detector.batch_image_detection("path/to/folder", batch_size=16)
+```
+
+The returned dictionary carries the detections (boxes, confidences, and class IDs) alongside the image identifier. Class IDs map through `detector.CLASS_NAMES`.
+
+## Classification
+
+Classifiers mirror the detection interface with `single_image_classification` and `batch_image_classification`. They are most often run on the crops a detector produces, which is the standard two-stage pattern in camera-trap analysis.
+
+```python
+from PytorchWildlife.models import classification as pw_classification
+
+classifier = pw_classification.AI4GAmazonRainforest(device=DEVICE)
+prediction = classifier.single_image_classification("path/to/crop.jpg")
+# prediction["prediction"] holds the species label; prediction["confidence"] the score
+```
+
+## Detect, then classify
+
+Because both stages share a consistent API, chaining them is straightforward: detect animals, crop each box, and classify the crop.
+
+```python
+import supervision as sv
+from PytorchWildlife.models import detection as pw_detection
+from PytorchWildlife.models import classification as pw_classification
+
+detector = pw_detection.MegaDetectorV6(device=DEVICE, version="MDV6-yolov10-e")
+classifier = pw_classification.AI4GOpossum(device=DEVICE)
+
+image = "path/to/image.jpg"
+det = detector.single_image_detection(image)
+
+import numpy as np
+from PIL import Image
+frame = np.array(Image.open(image).convert("RGB"))
+
+for box in det["detections"].xyxy:
+    crop = sv.crop_image(image=frame, xyxy=box)
+    label = classifier.single_image_classification(crop)
+    print(label["prediction"], label["confidence"])
+```
+
+## Saving results
+
+The `utils` module turns raw detections into the artifacts conservation workflows expect. These are the functions the demo scripts use:
+
+```python
+from PytorchWildlife import utils as pw_utils
+
+# Annotated images with boxes drawn on
+pw_utils.save_detection_images(results, "annotated_output", overwrite=False)
+
+# Cropped detections, one image per animal
+pw_utils.save_crop_images(results, "crop_output", overwrite=False)
+
+# Plain JSON
+pw_utils.save_detection_json(results, "results.json",
+                             categories=detector.CLASS_NAMES)
+
+# Timelapse-compatible JSON for ecologists' existing tooling
+pw_utils.save_detection_timelapse_json(results, "results_timelapse.json",
+                                       categories=detector.CLASS_NAMES,
+                                       info={"detector": "MegaDetectorV6"})
+```
+
+For point-based detectors such as HerdNet, the dot-style variants `save_detection_images_dots` and `save_detection_json_as_dots` render and export results as points instead of boxes.
+
+## Video
+
+The `process_video` helper runs any per-frame callback across a video and writes an annotated copy, with a progress bar and selectable codec:
+
+```python
+from PytorchWildlife import utils as pw_utils
+
+pw_utils.process_video(
+    source_path="input.mp4",
+    target_path="output.mp4",
+    callback=my_frame_callback,   # takes (frame, index), returns an annotated frame
+    target_fps=1,
+)
+```
+
+A complete video pipeline that detects and classifies every frame lives in `demo/video_demo.py`. See [inference examples](inference-examples.md) for the full walkthrough.
+
+## Bioacoustics
+
+Audio classification uses the same package, exposed through the `bioacoustics` namespace. The `ResNetClassifier` supports both binary and multiclass setups:
+
+```python
+from PytorchWildlife.models import bioacoustics as pw_bioacoustics
+
+model = pw_bioacoustics.ResNetClassifier(num_classes=2)
+```
+
+The framework provides the runtime here; the trained audio models and end-to-end audio pipelines are documented at [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/).
+
+## Where to go next
+
+- Browse every loadable model in the [Wildlife Model Zoo](model_zoo.md).
+- Follow runnable end-to-end scripts on the [inference examples](inference-examples.md) page.
+- Set up your environment with the [installation guide](installation.md).

--- a/docs/api.md
+++ b/docs/api.md
@@ -148,7 +148,7 @@ from PytorchWildlife.models import bioacoustics as pw_bioacoustics
 model = pw_bioacoustics.ResNetClassifier(num_classes=2)
 ```
 
-The framework provides the runtime here; the trained audio models and end-to-end audio pipelines are documented at [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/).
+The framework provides the runtime here; the trained audio models and end-to-end audio pipelines are documented at MegaDetector-Acoustic (documentation coming soon).
 
 ## Where to go next
 

--- a/docs/build_mkdocs.md
+++ b/docs/build_mkdocs.md
@@ -57,7 +57,7 @@ The site is available at `http://127.0.0.1:8000/`.
 
 ## 4. Deploy to GitHub Pages
 
-Push any change to `docs/**`, `mkdocs.yml`, or `docs-requirements.txt` on the `main` branch — GitHub Actions deploys automatically.
+Push any change to `docs/**`, `mkdocs.yml`, or `docs-requirements.txt` on the `main` branch. GitHub Actions deploys automatically.
 
 To deploy manually:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,79 +1,86 @@
 ---
-description: "PyTorch-Wildlife: unified open-source AI framework from Microsoft AI for Good Lab for camera-trap detection, species classification, and wildlife monitoring."
+title: "PyTorch-Wildlife: Conservation Deep Learning Framework"
+description: "PyTorch-Wildlife is the open-source conservation deep learning framework and wildlife model zoo from the Microsoft AI for Good Lab. Runs MegaDetector fast."
 tags:
   - PyTorch-Wildlife
+  - wildlife AI framework
+  - conservation deep learning framework
+  - wildlife model zoo
+  - pytorchwildlife pip install
   - MegaDetector
-  - wildlife AI
-  - camera trap detection
   - species classification
-  - conservation AI
-  - Microsoft AI for Good
 ---
 
-![PyTorch-Wildlife — open-source AI framework for wildlife monitoring from the Microsoft AI for Good Lab](https://zenodo.org/records/15376499/files/Pytorch_Banner_transparentbk.png)
+![PyTorch-Wildlife, the open-source conservation deep learning framework from the Microsoft AI for Good Lab](https://zenodo.org/records/15376499/files/Pytorch_Banner_transparentbk.png)
 
-# PyTorch-Wildlife
+# PyTorch-Wildlife: A Wildlife AI Framework
 
 > [!TIP]
-> PyTorch-Wildlife is part of the [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) umbrella — the hub for all AI for Good Lab wildlife tools. MegaDetector lives at [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector).
+> PyTorch-Wildlife is part of the [microsoft/Biodiversity](https://microsoft.github.io/Biodiversity/) umbrella, the hub for every AI for Good Lab wildlife tool. Looking for the camera-trap detection model on its own? See [MegaDetector](https://microsoft.github.io/MegaDetector/).
 
-**PyTorch-Wildlife is the unified open-source AI framework from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good) for wildlife monitoring.** It hosts detection models, species classifiers, and the tools needed to run them — from single-image inference to large-scale batch processing across camera-trap datasets.
+**PyTorch-Wildlife is the open-source conservation deep learning framework from the [Microsoft AI for Good Lab](https://www.microsoft.com/en-us/ai/ai-for-good).** One Python package gives you a tested wildlife model zoo, a consistent load-and-run API, and the data utilities that turn a folder of camera-trap images into structured detections. You write a few lines; the framework handles weight downloads, batching, and output formatting.
 
-Our mission is to create a global community where conservation scientists can collaborate — sharing datasets and deep learning architectures for wildlife conservation. PyTorch-Wildlife provides the shared foundation that every project in our ecosystem builds on.
+The goal is a shared foundation that conservation scientists can build on together: common model interfaces, reusable training and inference code, and a place to publish new architectures so the whole community benefits. Every modality-focused project in our ecosystem plugs into this framework rather than reinventing it.
 
+## Why a framework, not just a model
+
+A single detection model solves one problem. Real conservation pipelines need detection, classification, batch processing, video support, and exportable results that downstream tools can read. PyTorch-Wildlife packages all of that behind one import:
+
+- **A unified model zoo.** Detection and classification models load with one line and fetch their own weights. Swap `MegaDetectorV6` for `MegaDetectorV5` or a different classifier without rewriting your pipeline.
+- **A consistent inference API.** Every detector exposes `single_image_detection` and `batch_image_detection`; every classifier exposes `single_image_classification` and `batch_image_classification`. Learn it once.
+- **Conservation-ready outputs.** Built-in utilities save annotated images, cropped detections, and JSON, including a Timelapse-compatible format for ecologists' existing workflows.
+- **Framework support across modalities.** Vision detection, species classification, and bioacoustic classifiers all share the same package, so a multi-modal pipeline is a few imports rather than a few dependencies.
 
 ## Quick Start
+
+Install the framework from PyPI:
 
 ```bash
 pip install PytorchWildlife
 ```
 
+Run detection and classification in a handful of lines. Model weights download automatically on first use:
+
 ```python
-import numpy as np
 from PytorchWildlife.models import detection as pw_detection
 from PytorchWildlife.models import classification as pw_classification
 
-# Detection — MegaDetector V6, weights download automatically
+# Detection with MegaDetector V6
 detection_model = pw_detection.MegaDetectorV6()
 detection_result = detection_model.single_image_detection("path/to/image.jpg")
 
-# Classification
+# Species classification
 classification_model = pw_classification.AI4GAmazonRainforest()
 classification_result = classification_model.single_image_classification("path/to/image.jpg")
 ```
 
-**Try without installing:**
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — upload images in your browser
-- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing) — free cloud GPU
+New to the package? The [installation guide](installation.md) covers GPU setup, Docker, and Windows, and the [API overview](api.md) walks through the detection and classification interfaces with runnable examples.
 
+**Try it without installing anything:**
+
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife): upload images in your browser
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing): free cloud GPU
 
 ## What's Inside
 
-PyTorch-Wildlife provides a modular set of building blocks:
+PyTorch-Wildlife ships a modular set of building blocks:
 
-- **Detection models** — MegaDetector V5/V6 (multiple architectures), Deepfaune detector, HerdNet for aerial imagery
-- **Classification models** — Amazon Rainforest, Snapshot Serengeti, Opossum, Deepfaune, DFNE (New England)
-- **Bioacoustic models** — audio-based wildlife identification
-- **Data utilities** — transforms, datasets, batch processing, video support
-- **Demo notebooks** — Jupyter notebooks and Gradio web UI for hands-on exploration
+- **Detection models.** MegaDetector V5 and V6 across several architectures, the Deepfaune detector, and HerdNet for aerial imagery. See the [Wildlife Model Zoo](model_zoo.md).
+- **Classification models.** Region-specific species classifiers for the Amazon, the Serengeti, Europe, and more.
+- **Bioacoustic models.** A ResNet-based audio classifier for sound-based monitoring.
+- **Data and output utilities.** Transforms, datasets, batch dataloaders, video processing, and JSON exporters.
+- **Demos.** Jupyter notebooks, runnable Python scripts, and a Gradio web UI. See [inference examples](inference-examples.md).
 
-See the [Model Zoo](model_zoo.md) for the full list with performance benchmarks.
+For the complete list with versions and load commands, head to the [Wildlife Model Zoo](model_zoo.md).
 
+## Related Microsoft biodiversity AI projects
 
-## Part of the Biodiversity Ecosystem
+PyTorch-Wildlife is the framework layer. The modality-specific tools in the ecosystem each own their domain, and the framework provides support for running them:
 
-PyTorch-Wildlife is one project in a larger open-source ecosystem from the AI for Good Lab:
-
-| Repo | Purpose |
-|---|---|
-| [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) | The umbrella repository — documentation hub for the AI for Good Lab's biodiversity work |
-| [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | This repo — the unified deep learning framework |
-| [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | Animal detection in camera-trap imagery |
-| [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — AI-enabled edge device |
-| [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic models for audio-based wildlife monitoring |
-| [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
-| [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Point-based detection for overhead and aerial imagery |
-| [SPARROW Studio](https://github.com/microsoft/Biodiversity/tree/main/SPARROW-Studio) | Desktop application for running all models with a graphical interface |
+- [microsoft/Biodiversity](https://microsoft.github.io/Biodiversity/): the umbrella hub documenting every AI for Good Lab biodiversity tool.
+- [MegaDetector](https://microsoft.github.io/MegaDetector/): the camera-trap animal detection model, invoked through this framework.
+- [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/): bioacoustic models for audio-based wildlife monitoring.
+- [SPARROW](https://microsoft.github.io/SPARROW/): the solar-powered edge device that runs these models in the field.
 
 > [!TIP]
-> If you have any questions, please [email us](mailto:zhongqimiao@microsoft.com) or join us on Discord: [![](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=PyTorch-Wildlife)](https://discord.gg/TeEVxzaYtm)
+> Questions? [Email us](mailto:zhongqimiao@microsoft.com) or join us on Discord: [![Join the PyTorch-Wildlife Discord](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=PyTorch-Wildlife)](https://discord.gg/TeEVxzaYtm)

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ PyTorch-Wildlife is the framework layer. The modality-specific tools in the ecos
 
 - [microsoft/Biodiversity](https://microsoft.github.io/Biodiversity/): the umbrella hub documenting every AI for Good Lab biodiversity tool.
 - [MegaDetector](https://microsoft.github.io/MegaDetector/): the camera-trap animal detection model, invoked through this framework.
-- [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/): bioacoustic models for audio-based wildlife monitoring.
+- MegaDetector-Acoustic (documentation coming soon): bioacoustic models for audio-based wildlife monitoring.
 - [SPARROW](https://microsoft.github.io/SPARROW/): the solar-powered edge device that runs these models in the field.
 
 > [!TIP]

--- a/docs/inference-examples.md
+++ b/docs/inference-examples.md
@@ -116,5 +116,5 @@ The `demo/` directory also includes notebooks and scripts for the detect-then-cl
 
 - [microsoft/Biodiversity](https://microsoft.github.io/Biodiversity/): the umbrella hub for AI for Good Lab biodiversity tools.
 - [MegaDetector](https://microsoft.github.io/MegaDetector/): the camera-trap detection model behind these examples.
-- [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/): audio-based monitoring models.
+- MegaDetector-Acoustic (documentation coming soon): audio-based monitoring models.
 - [SPARROW](https://microsoft.github.io/SPARROW/): the solar-powered edge device for running models in the field.

--- a/docs/inference-examples.md
+++ b/docs/inference-examples.md
@@ -1,0 +1,120 @@
+---
+title: "Inference Examples: Run Wildlife Models at Scale"
+description: "Runnable PyTorch-Wildlife inference examples: single image, batch folder, video, and the Gradio web UI. Export annotated images, crops, and Timelapse JSON."
+tags:
+  - PyTorch-Wildlife inference
+  - batch image detection
+  - wildlife model zoo
+  - conservation deep learning framework
+  - MegaDetector batch
+---
+
+# Inference Examples
+
+PyTorch-Wildlife ships runnable demo scripts so you can go from a fresh install to real output without writing your own harness first. This page walks through the common ways to run inference: one image, a whole folder, a video, and an interactive web UI. Each example maps to a script under the repository's `demo/` directory.
+
+Before you start, install the framework with the [installation guide](installation.md) and skim the [API overview](api.md) so the method names below feel familiar.
+
+> [!TIP]
+> The demo scripts are written in cell style (`#%%`), so they run top to bottom as a plain `python demo/<script>.py`, or block by block in an interactive window.
+
+## Single image
+
+The smallest useful run: load a detector, detect one image, and save annotated and cropped output.
+
+```python
+import torch
+from PytorchWildlife.models import detection as pw_detection
+from PytorchWildlife import utils as pw_utils
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+detector = pw_detection.MegaDetectorV6(device=DEVICE, version="MDV6-yolov10-e")
+
+results = detector.single_image_detection("demo_data/imgs/10050028_0.JPG")
+
+pw_utils.save_detection_images(results, "demo_output", overwrite=False)
+pw_utils.save_crop_images(results, "crop_output", overwrite=False)
+```
+
+This mirrors `demo/image_demo.py`.
+
+## Batch a folder of images
+
+For real camera-trap surveys you run thousands of images at once. `batch_image_detection` takes a folder path and a `batch_size`, and the JSON exporters write results in formats downstream tools can read, including a Timelapse-compatible export.
+
+```python
+folder = "demo_data/imgs"
+results = detector.batch_image_detection(folder, batch_size=16)
+
+# Annotated images and crops
+pw_utils.save_detection_images(results, "batch_output", folder, overwrite=False)
+pw_utils.save_crop_images(results, "crop_output", folder, overwrite=False)
+
+# Plain and Timelapse JSON
+pw_utils.save_detection_json(results, "batch_output.json",
+                             categories=detector.CLASS_NAMES)
+pw_utils.save_detection_timelapse_json(results, "batch_output_timelapse.json",
+                                       categories=detector.CLASS_NAMES,
+                                       info={"detector": "MegaDetectorV6"})
+```
+
+This mirrors `demo/image_demo.py`.
+
+## Detect and classify video
+
+`demo/video_demo.py` runs a detector and a classifier on every sampled frame and writes an annotated video. The pattern is a per-frame callback handed to `process_video`:
+
+```python
+import numpy as np
+import supervision as sv
+import torch
+from PytorchWildlife.models import detection as pw_detection
+from PytorchWildlife.models import classification as pw_classification
+from PytorchWildlife import utils as pw_utils
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+detector = pw_detection.MegaDetectorV6(device=DEVICE, version="MDV6-yolov10-e")
+classifier = pw_classification.AI4GOpossum(device=DEVICE)
+
+box_annotator = sv.BoxAnnotator(thickness=4)
+
+def callback(frame: np.ndarray, index: int) -> np.ndarray:
+    det = detector.single_image_detection(frame, img_path=index)
+    labels = []
+    for box in det["detections"].xyxy:
+        crop = sv.crop_image(image=frame, xyxy=box)
+        clf = classifier.single_image_classification(crop)
+        labels.append("{} {:.2f}".format(clf["prediction"], clf["confidence"]))
+    return box_annotator.annotate(scene=frame, detections=det["detections"])
+
+pw_utils.process_video(
+    source_path="demo_data/videos/opossum_example.MP4",
+    target_path="demo_data/videos/opossum_example_processed.MP4",
+    callback=callback,
+    target_fps=1,
+)
+```
+
+## Interactive web UI
+
+`demo/gradio_demo.py` launches a browser-based interface for uploading images and viewing detections, useful for demos and quick checks without writing code:
+
+```bash
+python demo/gradio_demo.py
+```
+
+The same interface is hosted online if you would rather not run anything locally:
+
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife): upload images in your browser.
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing): free cloud GPU.
+
+## More demos
+
+The `demo/` directory also includes notebooks and scripts for the detect-then-classify pipeline (`detection_classification_pipeline_demo.py`), HerdNet aerial detection (`image_demo_herdnet.py`), and image separation by detection result (`image_separation_demo.py`).
+
+## Related Microsoft biodiversity AI projects
+
+- [microsoft/Biodiversity](https://microsoft.github.io/Biodiversity/): the umbrella hub for AI for Good Lab biodiversity tools.
+- [MegaDetector](https://microsoft.github.io/MegaDetector/): the camera-trap detection model behind these examples.
+- [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/): audio-based monitoring models.
+- [SPARROW](https://microsoft.github.io/SPARROW/): the solar-powered edge device for running models in the field.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,28 +1,36 @@
 ---
-description: "Install PyTorch-Wildlife for camera-trap AI and wildlife detection. Supports pip, conda, and Docker on Windows, macOS, and Linux with optional CUDA GPU acceleration."
+title: "Install PyTorch-Wildlife: pip, Conda, Docker"
+description: "Install PyTorch-Wildlife (pytorchwildlife pip install) for camera-trap AI. Covers pip, Conda, and Docker on Windows, macOS, and Linux, plus CUDA GPU setup."
 tags:
   - PyTorch-Wildlife installation
-  - pip install PytorchWildlife
+  - pytorchwildlife pip install
   - conda environment
-  - wildlife AI setup
-  - MegaDetector install
+  - wildlife AI framework
   - GPU CUDA setup
 ---
 
 # Installation
 
+PyTorch-Wildlife installs as a single PyPI package, `PytorchWildlife`, on Windows, macOS, and Linux. The fastest path is a one-line `pip install`; the sections below add GPU acceleration, Docker, and platform-specific notes. Once it is installed, the [API overview](api.md) and [inference examples](inference-examples.md) show what to do next.
+
 ## Prerequisites
 
-- Python 3.8+ (3.10+ recommended)
-- Optional: NVIDIA GPU with CUDA 12.1 for 10–50x speedup
+- Python 3.8 or newer (3.10+ recommended)
+- Optional: an NVIDIA GPU with CUDA 12.1 for a large speedup on batch jobs
 
-## pip
+## pip install PytorchWildlife
+
+The package name on PyPI is `PytorchWildlife`:
 
 ```bash
 pip install PytorchWildlife
 ```
 
+That single command pulls in the detection and classification models, the data utilities, and their dependencies. Model weights are not bundled; each model downloads its own weights automatically the first time you load it.
+
 ## Conda
+
+A clean Conda environment keeps the install isolated from other projects:
 
 ```bash
 conda create -n pytorch-wildlife python=3.10 -y
@@ -30,21 +38,20 @@ conda activate pytorch-wildlife
 pip install PytorchWildlife
 ```
 
-> **Windows users:** Use the Anaconda Prompt if using Anaconda, otherwise use PowerShell.
-
+> **Windows users:** use the Anaconda Prompt with Anaconda, or PowerShell otherwise.
 
 ## GPU Setup
 
-### Check if CUDA is available
+### Check whether CUDA is available
 
 ```python
 import torch
 print(torch.cuda.is_available())
 ```
 
-### Install GPU-enabled PyTorch (CUDA 12.1)
+### Install a GPU-enabled PyTorch (CUDA 12.1)
 
-If `torch.cuda.is_available()` returns `False` on a CUDA machine:
+If `torch.cuda.is_available()` returns `False` on a CUDA-capable machine, reinstall PyTorch from the CUDA wheel index, then reinstall the framework:
 
 ```bash
 pip uninstall torch torchvision torchaudio
@@ -52,14 +59,14 @@ pip install torch torchvision torchaudio --index-url https://download.pytorch.or
 pip install PytorchWildlife
 ```
 
-### Ubuntu — OpenCV dependency
+### Ubuntu: OpenCV dependency
 
 ```bash
 sudo apt-get update
 sudo apt-get install -y python3-opencv
 ```
 
-### macOS — ffmpeg for video decoding
+### macOS: ffmpeg for video decoding
 
 ```bash
 brew install ffmpeg
@@ -67,10 +74,9 @@ brew install ffmpeg
 
 ### Windows
 
-See the [Windows installation guide](https://zenodo.org/records/15376499/files/PytorchWildlife_Windows_installation_tutorial.pdf) for a step-by-step walkthrough.
+The [Windows installation guide](https://zenodo.org/records/15376499/files/PytorchWildlife_Windows_installation_tutorial.pdf) is a step-by-step walkthrough for setting up the environment from scratch.
 
-
-## Verify Installation
+## Verify the install
 
 ```python
 from PytorchWildlife.models import detection as pw_detection
@@ -79,30 +85,35 @@ model = pw_detection.MegaDetectorV6()
 print("PyTorch-Wildlife loaded successfully.")
 ```
 
-Model weights download automatically on first use.
-
-
-## Try Without Installing
-
-- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) — upload images in your browser
-- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing) — free cloud GPU
-
+Weights download automatically on first load, so the first call is slower than later ones.
 
 ## Docker
+
+A prebuilt image runs the Gradio demo without a local Python setup:
 
 ```bash
 docker pull andreshdz/pytorchwildlife:1.0.2.3
 docker run -p 80:80 andreshdz/pytorchwildlife:1.0.2.3 python demo/gradio_demo.py
 ```
 
+## Jupyter notebooks
 
-## Jupyter Notebooks
-
-To use the demo notebooks with Jupyter:
+To run the demo notebooks under your environment, register it as a Jupyter kernel:
 
 ```bash
 conda install ipykernel
 python -m ipykernel install --user --name pytorch-wildlife --display-name "Python (PytorchWildlife)"
 ```
 
-Then select the `Python (PytorchWildlife)` kernel when running notebooks.
+Then select the `Python (PytorchWildlife)` kernel when opening a notebook.
+
+## Try it without installing
+
+- [Hugging Face demo](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife): upload images in your browser.
+- [Google Colab notebook](https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing): free cloud GPU.
+
+## Next steps
+
+- Pick a model from the [Wildlife Model Zoo](model_zoo.md).
+- Learn the load-and-run interface in the [API overview](api.md).
+- Run end-to-end scripts on the [inference examples](inference-examples.md) page.

--- a/docs/model_zoo.md
+++ b/docs/model_zoo.md
@@ -124,11 +124,11 @@ from PytorchWildlife.models import bioacoustics as pw_bioacoustics
 model = pw_bioacoustics.ResNetClassifier(num_classes=2)
 ```
 
-For the dedicated bioacoustic model zoo and audio pipelines, the framework provides support for, but does not own, that modality. See [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/).
+For the dedicated bioacoustic model zoo and audio pipelines, the framework provides support for, but does not own, that modality. See MegaDetector-Acoustic (documentation coming soon).
 
 ## Related Microsoft biodiversity AI projects
 
 - [microsoft/Biodiversity](https://microsoft.github.io/Biodiversity/): the umbrella hub for every AI for Good Lab biodiversity tool.
 - [MegaDetector](https://microsoft.github.io/MegaDetector/): the camera-trap detection model whose weights this zoo serves.
-- [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/): the bioacoustic model family for audio monitoring.
+- MegaDetector-Acoustic (documentation coming soon): the bioacoustic model family for audio monitoring.
 - [SPARROW](https://microsoft.github.io/SPARROW/): the solar-powered edge device that runs these models in the field.

--- a/docs/model_zoo.md
+++ b/docs/model_zoo.md
@@ -1,23 +1,25 @@
 ---
-description: "PyTorch-Wildlife model zoo: MegaDetector V5/V6 detection models, species classifiers (Amazon, Serengeti, Deepfaune), and bioacoustic models for wildlife monitoring."
+title: "Wildlife Model Zoo: MegaDetector and Species Classifiers"
+description: "The PyTorch-Wildlife model zoo: MegaDetector V5 and V6 detectors, region-specific species classifiers, HerdNet, and bioacoustic models. Each loads in one line."
 tags:
-  - PyTorch-Wildlife model zoo
+  - wildlife model zoo
+  - PyTorch-Wildlife
   - MegaDetector versions
   - species classification models
-  - wildlife AI models
-  - camera trap models
+  - conservation deep learning framework
 ---
 
-# Model Zoo
+# Wildlife Model Zoo
 
-PyTorch-Wildlife provides a growing library of detection, classification, and bioacoustic models. All models load with a single line and download weights automatically.
+The PyTorch-Wildlife model zoo is the catalog of detection, classification, and bioacoustic models that ship with the framework. Every entry loads with a single constructor call and downloads its own weights on first use, so you can compare architectures or swap a model without touching the rest of your pipeline.
 
+If you are new to the package, install it first with the [installation guide](installation.md), then come back here to pick a model. The [API overview](api.md) shows how to feed images into any model below.
 
 ## Detection Models
 
 ### MegaDetector V6
 
-The latest generation of MegaDetector, trained on diverse global camera-trap datasets. Multiple architecture variants are available to trade off accuracy vs. speed vs. licensing.
+The current generation of [MegaDetector](https://microsoft.github.io/MegaDetector/), trained on diverse global camera-trap datasets. Several architecture variants let you trade accuracy against speed and licensing. The framework provides three wrapper classes so you can pick the license your project needs.
 
 | Version | Architecture | License | Load with |
 |---|---|---|---|
@@ -33,50 +35,49 @@ The latest generation of MegaDetector, trained on diverse global camera-trap dat
 ```python
 from PytorchWildlife.models import detection as pw_detection
 
-# Default (AGPL, YOLOv10)
-detector = pw_detection.MegaDetectorV6()
+# Default AGPL build (YOLOv10 Extra is the recommended starting point)
+detector = pw_detection.MegaDetectorV6(version="MDV6-yolov10-e")
 
-# MIT-licensed YOLO
+# MIT-licensed YOLOv9 weights
 detector = pw_detection.MegaDetectorV6MIT(version="MDV6-mit-yolov9-e")
 
-# Apache RT-DETR
+# Apache-2.0 RT-DETR weights
 detector = pw_detection.MegaDetectorV6Apache(version="MDV6-apa-rtdetr-e")
 ```
 
 ### MegaDetector V5
 
-The previous generation, widely deployed across conservation organizations. Uses YOLOv5.
+The previous generation, still widely deployed across conservation organizations. Built on YOLOv5.
 
 ```python
 detector = pw_detection.MegaDetectorV5()
 ```
 
-For V5 model weights and earlier versions, see the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository.
+For V5 weights and earlier releases, see the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository.
 
 ### Deepfaune Detector
 
-Trained for European ecosystems. The first third-party camera-trap detection model integrated into PyTorch-Wildlife.
+A detector tuned for European ecosystems, and the first third-party camera-trap model integrated into the framework.
 
 ```python
 detector = pw_detection.DeepfauneDetector()
 ```
 
-See the [Deepfaune website](https://www.deepfaune.cnrs.fr/en/) for more details.
+See the [Deepfaune project](https://www.deepfaune.cnrs.fr/en/) for background on the underlying model.
 
 ### HerdNet
 
-Point-based localization model for overhead and aerial imagery.
+A point-based localization model for overhead and aerial imagery, where animals appear as small dots rather than large bounding boxes.
 
 ```python
 detector = pw_detection.HerdNet()
 ```
 
-
 ## Classification Models
 
-All classifiers can be paired with any detection model to build a detection + classification pipeline.
+Classifiers turn a detected animal crop into a species label. Pair any classifier with any detector to build a two-stage detect-then-classify pipeline.
 
-| Model | Class | Geography | Species |
+| Model | Class | Geography | Coverage |
 |---|---|---|---|
 | AI4G Amazon Rainforest | `AI4GAmazonRainforest` | Amazon | ~36 species |
 | AI4G Snapshot Serengeti | `AI4GSnapshotSerengeti` | African savanna | ~48 species |
@@ -93,30 +94,41 @@ classifier = pw_classification.DeepfauneClassifier()
 classifier = pw_classification.DFNE()
 ```
 
+> [!TIP]
+> Need a classifier for a region or species set that is not listed here? The [MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) project covers fine-tuning a classifier on your own labeled data.
 
-## Detection + Classification Pipeline
+## Detection plus Classification Pipeline
+
+Run a detector to find animals, then send each crop to a classifier for a species label:
 
 ```python
 from PytorchWildlife.models import detection as pw_detection
 from PytorchWildlife.models import classification as pw_classification
 
-detection_model = pw_detection.MegaDetectorV6()
+detection_model = pw_detection.MegaDetectorV6(version="MDV6-yolov10-e")
 classification_model = pw_classification.AI4GAmazonRainforest()
 
-# Detect, then classify crops
 detection_result = detection_model.single_image_detection("image.jpg")
 classification_result = classification_model.single_image_classification("image.jpg")
 ```
 
-For a full pipeline demo, see the `demo/detection_classification_pipeline_demo.py` script.
-
+The `demo/detection_classification_pipeline_demo.py` script shows the full two-stage flow end to end. More runnable walkthroughs live on the [inference examples](inference-examples.md) page.
 
 ## Bioacoustic Models
+
+The framework also includes a ResNet-based classifier for audio, so sound-based monitoring shares the same package as vision.
 
 ```python
 from PytorchWildlife.models import bioacoustics as pw_bioacoustics
 
-model = pw_bioacoustics.BioacousticsResnetClassifier()
+model = pw_bioacoustics.ResNetClassifier(num_classes=2)
 ```
 
-For the full bioacoustic model zoo, see [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic).
+For the dedicated bioacoustic model zoo and audio pipelines, the framework provides support for, but does not own, that modality. See [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/).
+
+## Related Microsoft biodiversity AI projects
+
+- [microsoft/Biodiversity](https://microsoft.github.io/Biodiversity/): the umbrella hub for every AI for Good Lab biodiversity tool.
+- [MegaDetector](https://microsoft.github.io/MegaDetector/): the camera-trap detection model whose weights this zoo serves.
+- [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/): the bioacoustic model family for audio monitoring.
+- [SPARROW](https://microsoft.github.io/SPARROW/): the solar-powered edge device that runs these models in the field.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,8 @@ nav:
     - Overview: index.md
     - Installation: installation.md
     - Model Zoo: model_zoo.md
+    - API Overview: api.md
+    - Inference Examples: inference-examples.md
     - Tags: tags.md
   - Cite Us: cite.md
   - Developer Guide: build_mkdocs.md


### PR DESCRIPTION
## Summary

Content-depth SEO pass for the PyTorch-Wildlife docs site, claiming the cluster's **framework / library / model zoo / training / inference** keyword lane. Prose standardizes on "conservation deep learning framework". All API, model, and CLI-style details are sourced from the real package (`src/PytorchWildlife/**`) and `demo/` scripts; nothing was invented.

Stacked on the infra branch: base is `seo/pw-infra-structured-data` (infra PR #15). On merge of #15, this PR's base retargets to `main`.

## Keyword lane

Priority: `pytorch wildlife`, `wildlife AI framework`, `conservation deep learning framework`, `wildlife model zoo`, `pytorchwildlife pip install`. Boundary respected: the framework supports detection / audio / hardware but does not own them. Camera-trap detection links to MegaDetector, audio to MegaDetector-Acoustic, hardware to SPARROW; siblings are framed as the modality owners.

## Pages added

- `docs/api.md` (API Overview): editorial tour of the load-and-run API with runnable detection, classification, detect-then-classify, video, and bioacoustics examples drawn from real method signatures (`single_image_detection`, `batch_image_detection`, `single_image_classification`, `process_video`, `save_detection_*`).
- `docs/inference-examples.md` (Inference Examples): single-image, batch-folder, video, and Gradio web-UI walkthroughs mapped to the actual `demo/` scripts.

## Pages deepened

- `docs/index.md`: leads with the value prop, "why a framework not just a model" section, standardized framework phrasing, em-dashes removed, ecosystem block reframed so siblings own their modalities.
- `docs/model_zoo.md`: H1 promoted to **Wildlife Model Zoo**; real model tables (MegaDetector V6 variants by license, V5, Deepfaune, HerdNet; classifiers with classes/geography/coverage); related-projects block.
- `docs/installation.md`: keyword-first title/description for "pytorchwildlife pip install"; tightened sections; next-steps cross-links.

## Internal linking

Each new page has 3+ inbound links, descriptive anchors, a hub backlink to microsoft.github.io/Biodiversity, and a "Related Microsoft biodiversity AI projects" block. Nav updated in `mkdocs.yml` (API Overview, Inference Examples).

## Gates passed

- `mkdocs build --strict`: clean (no link/nav errors; only benign git-timestamp notices for the two new files).
- `grep -rn '—' docs/`: clean (also fixed one pre-existing em-dash in `build_mkdocs.md`).
- New pages render; `[!TIP]` callouts render as admonitions; internal links resolve.
- Front-matter on all 5 edited/new pages: keyword-first title, 110-160 char description, lane tags.
- Originality: paraphrased, no verbatim README copying.
- Touched only `docs/**` and `mkdocs.yml`. No `src/`, `pyproject.toml`, demo code, or CI changed. `site/` not staged.

## Claims to verify (@zhmiao)

None. Every model name, class name, version string, license, method signature, and CLI/demo detail was read directly from `src/PytorchWildlife/**` and `demo/`. Two minor judgment calls worth a glance:

- No installed CLI exists (no `console_scripts` in `pyproject.toml`), so no CLI page was created. Command-line usage is documented via the runnable `demo/` scripts on the Inference Examples page instead.
- Species counts (~36 Amazon, ~48 Serengeti, ~44 Deepfaune) carried over from the existing model_zoo.md; Amazon's ~36 is confirmed by `num_cls=36` in the source, the others were not independently re-counted from weights.