### PR TITLE
feat: make Pytorch-Wildlife the release-ready framework home (port fixes + PyPI Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish to PyPI
+
+# Publishes the PytorchWildlife package to PyPI when a GitHub Release is published.
+# Uses PyPI Trusted Publishing (OIDC) -- no API token or stored secret is required.
+#
+# One-time maintainer setup (PyPI project owner, account-side):
+#   PyPI -> project "PytorchWildlife" -> Manage -> Publishing -> Add a trusted publisher (GitHub Actions):
+#     Owner:        microsoft
+#     Repository:   Pytorch-Wildlife
+#     Workflow:     publish.yml
+#     Environment:  pypi
+# After that, publishing a GitHub Release runs this workflow and uploads the build.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build and publish PytorchWildlife
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/PytorchWildlife/
+    permissions:
+      id-token: write   # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,5 +39,10 @@ jobs:
           python -m pip install --upgrade build
           python -m build
 
+      - name: Check distribution metadata
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "PytorchWildlife"
-version = "1.3.0"
+version = "1.3.1"
 description = "PyTorch-Wildlife: unified open-source AI framework for camera-trap detection, species classification, and wildlife monitoring."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/PytorchWildlife/data/datasets.py
+++ b/src/PytorchWildlife/data/datasets.py
@@ -14,6 +14,7 @@ ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 # Making the DetectionImageFolder class available for import from this module
 __all__ = [
+    "ClassificationImageFolder",
     "DetectionImageFolder",
     ]
 

--- a/src/PytorchWildlife/models/classification/resnet_base/base_classifier.py
+++ b/src/PytorchWildlife/models/classification/resnet_base/base_classifier.py
@@ -158,10 +158,9 @@ class PlainResNetInference(BaseClassifierInference):
         """
 
         if data_path:
-            dataset = pw_data.ImageFolder(
+            dataset = pw_data.ClassificationImageFolder(
                 data_path,
                 transform=self.transform,
-                path_head='.'
             )
         elif det_results:
             dataset = pw_data.DetectionCrops(

--- a/src/PytorchWildlife/models/classification/timm_base/base_classifier.py
+++ b/src/PytorchWildlife/models/classification/timm_base/base_classifier.py
@@ -177,10 +177,9 @@ class TIMM_BaseClassifierInference(BaseClassifierInference):
         """
 
         if data_path:
-            dataset = pw_data.ImageFolder(
+            dataset = pw_data.ClassificationImageFolder(
                 data_path,
                 transform=self.transform,
-                path_head='.'
             )
         elif det_results:
             dataset = pw_data.DetectionCrops(

--- a/src/PytorchWildlife/models/detection/rtdetr_apache/megadetectorv6_apache.py
+++ b/src/PytorchWildlife/models/detection/rtdetr_apache/megadetectorv6_apache.py
@@ -20,7 +20,7 @@ class MegaDetectorV6Apache(RTDETRApacheBase):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-rtdetr-x-apache'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-apa-rtdetr-c'):
         """
         Initializes the MegaDetectorV6 model with the option to load pretrained weights.
         
@@ -28,7 +28,7 @@ class MegaDetectorV6Apache(RTDETRApacheBase):
             weights (str, optional): Path to the weights file.
             device (str, optional): Device to load the model on (e.g., "cpu" or "cuda"). Default is "cpu".
             pretrained (bool, optional): Whether to load the pretrained model. Default is True.
-            version (str, optional): Version of the model to load. Default is 'MDV6-rtdetr-x-apache'.
+            version (str, optional): Version of the model to load. Default is 'MDV6-apa-rtdetr-c'.
         """
         self.IMAGE_SIZE = 640
 

--- a/src/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6.py
+++ b/src/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6.py
@@ -20,7 +20,7 @@ class MegaDetectorV6(YOLOV8Base):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='yolov9c'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c'):
         """
         Initializes the MegaDetectorV5 model with the option to load pretrained weights.
         
@@ -28,7 +28,7 @@ class MegaDetectorV6(YOLOV8Base):
             weights (str, optional): Path to the weights file.
             device (str, optional): Device to load the model on (e.g., "cpu" or "cuda"). Default is "cpu".
             pretrained (bool, optional): Whether to load the pretrained model. Default is True.
-            version (str, optional): Version of the model to load. Default is 'yolov9c'.
+            version (str, optional): Version of the model to load. Default is 'MDV6-yolov9-c'.
         """
         self.IMAGE_SIZE = 1280
 

--- a/src/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6_distributed.py
+++ b/src/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6_distributed.py
@@ -20,7 +20,7 @@ class MegaDetectorV6_Distributed(YOLOV8_Distributed):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='yolov9c'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c'):
         """
         Initializes the MegaDetectorV5 model with the option to load pretrained weights.
         
@@ -28,7 +28,7 @@ class MegaDetectorV6_Distributed(YOLOV8_Distributed):
             weights (str, optional): Path to the weights file.
             device (str, optional): Device to load the model on (e.g., "cpu" or "cuda"). Default is "cpu".
             pretrained (bool, optional): Whether to load the pretrained model. Default is True.
-            version (str, optional): Version of the model to load. Default is 'yolov9c'.
+            version (str, optional): Version of the model to load. Default is 'MDV6-yolov9-c'.
         """
         self.IMAGE_SIZE = 1280
 

--- a/src/PytorchWildlife/models/detection/yolo_mit/megadetectorv6_mit.py
+++ b/src/PytorchWildlife/models/detection/yolo_mit/megadetectorv6_mit.py
@@ -20,7 +20,7 @@ class MegaDetectorV6MIT(YOLOMITBase):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c-mit'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-mit-yolov9-c'):
         """
         Initializes the MegaDetectorV6 model with the option to load pretrained weights.
         
@@ -28,7 +28,7 @@ class MegaDetectorV6MIT(YOLOMITBase):
             weights (str, optional): Path to the weights file.
             device (str, optional): Device to load the model on (e.g., "cpu" or "cuda"). Default is "cpu".
             pretrained (bool, optional): Whether to load the pretrained model. Default is True.
-            version (str, optional): Version of the model to load. Default is 'MDV6-yolov9-c-mit'.
+            version (str, optional): Version of the model to load. Default is 'MDV6-mit-yolov9-c'.
         """
         self.IMAGE_SIZE = 640
 


### PR DESCRIPTION
## What

Completes the repo split so **microsoft/Pytorch-Wildlife is the canonical, complete, release-ready home** for the `PytorchWildlife` framework. Prepares the PyPI cut-over so the maintainer's remaining action is minimal.

### Changes
- **Port 2 post-split bug fixes** from microsoft/Biodiversity (which still carried a leftover copy of the package after the 2026-05-14 split): the batch-classification `ClassificationImageFolder` fix (upstream PR #616) and the default MegaDetectorV6 version identifiers (upstream PR #613). After this, `src/PytorchWildlife` matches Biodiversity's package exactly (verified `diff -rq` clean) — so removing the leftover from Biodiversity loses nothing.
- **Version bump 1.3.0 → 1.3.1** (PyPI rejects re-uploading an existing version).
- **Tokenless PyPI Trusted Publishing workflow** (`.github/workflows/publish.yml`): builds + uploads on a published GitHub Release via OIDC. No API token, no stored secret.

### Why
PyPI's `PytorchWildlife` Home-page still points at the old CameraTraps/Biodiversity repo. This repo's `pyproject.toml` already declares `Homepage = github.com/microsoft/Pytorch-Wildlife`, so the next release cut from here **auto-corrects the PyPI link**.

### Verification
- `diff -rq Biodiversity/PytorchWildlife  Pytorch-Wildlife/src/PytorchWildlife` → clean (complete superset).
- Ported version IDs already exist in the weights registry; `ClassificationImageFolder` already defined. No behavior breakage.
- `python -m build` → `pytorchwildlife-1.3.1` sdist + wheel; wheel METADATA `Homepage` = github.com/microsoft/Pytorch-Wildlife.

### Maintainer action to publish (documented in the workflow header)
1. **One-time** (PyPI project owner): add a Trusted Publisher on the `PytorchWildlife` PyPI project — owner `microsoft`, repo `Pytorch-Wildlife`, workflow `publish.yml`, environment `pypi`.
2. Publish the pre-staged GitHub Release → the workflow uploads 1.3.1 and PyPI flips to Pytorch-Wildlife.

Part of resolving the hub/framework duplication (ADO Epic 506340). No reviewer set per current instruction.