### PR TITLE
docs(seo): host the full PytorchWildlife API reference on the framework site

### DIFF
--- a/docs/base/data/datasets.md
+++ b/docs/base/data/datasets.md
@@ -1,0 +1,3 @@
+# Datasets Module
+
+::: PytorchWildlife.data.datasets

--- a/docs/base/data/transforms.md
+++ b/docs/base/data/transforms.md
@@ -1,0 +1,3 @@
+# Transforms Module
+
+::: PytorchWildlife.data.transforms

--- a/docs/base/models/classification/base_classifier.md
+++ b/docs/base/models/classification/base_classifier.md
@@ -1,0 +1,3 @@
+# Base Classifier
+
+::: PytorchWildlife.models.classification.base_classifier

--- a/docs/base/models/classification/resnet_base/amazon.md
+++ b/docs/base/models/classification/resnet_base/amazon.md
@@ -1,0 +1,3 @@
+# Amazon
+
+::: PytorchWildlife.models.classification.resnet_base.amazon

--- a/docs/base/models/classification/resnet_base/base_classifier.md
+++ b/docs/base/models/classification/resnet_base/base_classifier.md
@@ -1,0 +1,3 @@
+# ResNet Base
+
+::: PytorchWildlife.models.classification.resnet_base.base_classifier

--- a/docs/base/models/classification/resnet_base/custom_weights.md
+++ b/docs/base/models/classification/resnet_base/custom_weights.md
@@ -1,0 +1,3 @@
+# Custom Weights
+
+::: PytorchWildlife.models.classification.resnet_base.custom_weights

--- a/docs/base/models/classification/resnet_base/opossum.md
+++ b/docs/base/models/classification/resnet_base/opossum.md
@@ -1,0 +1,3 @@
+# Opossum
+
+::: PytorchWildlife.models.classification.resnet_base.opossum

--- a/docs/base/models/classification/resnet_base/serengeti.md
+++ b/docs/base/models/classification/resnet_base/serengeti.md
@@ -1,0 +1,3 @@
+# Serengeti
+
+::: PytorchWildlife.models.classification.resnet_base.serengeti

--- a/docs/base/models/classification/timm_base/DFNE.md
+++ b/docs/base/models/classification/timm_base/DFNE.md
@@ -1,0 +1,3 @@
+# DFNE
+
+::: PytorchWildlife.models.classification.timm_base.DFNE

--- a/docs/base/models/classification/timm_base/Deepfaune.md
+++ b/docs/base/models/classification/timm_base/Deepfaune.md
@@ -1,0 +1,3 @@
+# Deepfaune
+
+::: PytorchWildlife.models.classification.timm_base.Deepfaune

--- a/docs/base/models/classification/timm_base/base_classifier.md
+++ b/docs/base/models/classification/timm_base/base_classifier.md
@@ -1,0 +1,3 @@
+# Timm Base
+
+::: PytorchWildlife.models.classification.timm_base.base_classifier

--- a/docs/base/models/detection/base_detector.md
+++ b/docs/base/models/detection/base_detector.md
@@ -1,0 +1,3 @@
+# Base Detector
+
+::: PytorchWildlife.models.detection.base_detector

--- a/docs/base/models/detection/herdnet.md
+++ b/docs/base/models/detection/herdnet.md
@@ -1,0 +1,3 @@
+# HerdNet
+
+::: PytorchWildlife.models.detection.localization.herdnet

--- a/docs/base/models/detection/herdnet/animaloc/data/patches.md
+++ b/docs/base/models/detection/herdnet/animaloc/data/patches.md
@@ -1,0 +1,3 @@
+# Patches
+
+::: PytorchWildlife.models.detection.localization.animaloc.data.patches

--- a/docs/base/models/detection/herdnet/animaloc/data/types.md
+++ b/docs/base/models/detection/herdnet/animaloc/data/types.md
@@ -1,0 +1,3 @@
+# Types
+
+::: PytorchWildlife.models.detection.localization.animaloc.data.types

--- a/docs/base/models/detection/herdnet/animaloc/eval/lmds.md
+++ b/docs/base/models/detection/herdnet/animaloc/eval/lmds.md
@@ -1,0 +1,3 @@
+# LMDS
+
+::: PytorchWildlife.models.detection.localization.animaloc.eval.lmds

--- a/docs/base/models/detection/herdnet/animaloc/eval/stitchers.md
+++ b/docs/base/models/detection/herdnet/animaloc/eval/stitchers.md
@@ -1,0 +1,3 @@
+# Stitchers
+
+::: PytorchWildlife.models.detection.localization.animaloc.eval.stitchers

--- a/docs/base/models/detection/herdnet/dla.md
+++ b/docs/base/models/detection/herdnet/dla.md
@@ -1,0 +1,3 @@
+# DLA
+
+::: PytorchWildlife.models.detection.localization.dla

--- a/docs/base/models/detection/herdnet/model.md
+++ b/docs/base/models/detection/herdnet/model.md
@@ -1,0 +1,3 @@
+# Model
+
+::: PytorchWildlife.models.detection.localization.model

--- a/docs/base/models/detection/ultralytics_based/Deepfaune.md
+++ b/docs/base/models/detection/ultralytics_based/Deepfaune.md
@@ -1,0 +1,3 @@
+# Deepfaune
+
+::: PytorchWildlife.models.detection.ultralytics_based.Deepfaune

--- a/docs/base/models/detection/ultralytics_based/megadetectorv5.md
+++ b/docs/base/models/detection/ultralytics_based/megadetectorv5.md
@@ -1,0 +1,3 @@
+# MegaDetector v5
+
+::: PytorchWildlife.models.detection.ultralytics_based.megadetectorv5

--- a/docs/base/models/detection/ultralytics_based/megadetectorv6.md
+++ b/docs/base/models/detection/ultralytics_based/megadetectorv6.md
@@ -1,0 +1,3 @@
+# MegaDetector v6
+
+::: PytorchWildlife.models.detection.ultralytics_based.megadetectorv6

--- a/docs/base/models/detection/ultralytics_based/megadetectorv6_distributed.md
+++ b/docs/base/models/detection/ultralytics_based/megadetectorv6_distributed.md
@@ -1,0 +1,3 @@
+# MegaDetector v6 Distributed
+
+::: PytorchWildlife.models.detection.ultralytics_based.megadetectorv6_distributed

--- a/docs/base/models/detection/ultralytics_based/yolov5_base.md
+++ b/docs/base/models/detection/ultralytics_based/yolov5_base.md
@@ -1,0 +1,3 @@
+# YOLOv5 Base
+
+::: PytorchWildlife.models.detection.ultralytics_based.yolov5_base

--- a/docs/base/models/detection/ultralytics_based/yolov8_base.md
+++ b/docs/base/models/detection/ultralytics_based/yolov8_base.md
@@ -1,0 +1,3 @@
+# YOLOv8 Base
+
+::: PytorchWildlife.models.detection.ultralytics_based.yolov8_base

--- a/docs/base/models/detection/ultralytics_based/yolov8_distributed.md
+++ b/docs/base/models/detection/ultralytics_based/yolov8_distributed.md
@@ -1,0 +1,3 @@
+# YOLOv8 Distributed
+
+::: PytorchWildlife.models.detection.ultralytics_based.yolov8_distributed

--- a/docs/base/overview.md
+++ b/docs/base/overview.md
@@ -1,0 +1,37 @@
+# PytorchWildlife Base Module
+
+The `PytorchWildlife` base module is the core component of this repository, designed to facilitate wildlife detection and classification tasks using PyTorch. It provides utilities for data processing, model implementation, and post-processing. It is also what is currently packaged in our Python package.
+
+## Overview
+
+The module is structured into the following submodules:
+
+- **`data`**: Contains utilities for handling datasets and applying transformations.
+- **`models`**: Includes implementations for classification and detection models.
+- **`utils`**: Provides miscellaneous utilities for post-processing and other tasks.
+
+## Submodules
+
+### `data`
+- `datasets.py`: Defines dataset classes for loading and preprocessing data.
+- `transforms.py`: Implements data augmentation and transformation utilities.
+
+### `models`
+- `classification/`: Contains classification model architectures.
+- `detection/`: Includes detection model architectures.
+
+### `utils`
+- `misc.py`: Provides helper functions for miscellaneous tasks.
+- `post_process.py`: Implements post-processing utilities for model outputs.
+
+## Getting Started
+
+To use the `PytorchWildlife` module, import the required submodules as follows:
+
+```python
+from PytorchWildlife.data import datasets, transforms
+from PytorchWildlife.models import classification, detection
+from PytorchWildlife.utils import misc, post_process
+```
+
+Refer to the specific submodule documentation for detailed usage instructions.

--- a/docs/base/utils/misc.md
+++ b/docs/base/utils/misc.md
@@ -1,0 +1,1 @@
+::: PytorchWildlife.utils.misc

--- a/docs/base/utils/post_process.md
+++ b/docs/base/utils/post_process.md
@@ -1,0 +1,1 @@
+::: PytorchWildlife.utils.post_process

--- a/docs/fine_tuning_modules/classification/overview.md
+++ b/docs/fine_tuning_modules/classification/overview.md
@@ -1,0 +1,10 @@
+---
+description: "PyTorch-Wildlife classification fine-tuning — adapt species classifiers to your own datasets and geographic regions."
+tags:
+  - PyTorch-Wildlife
+  - classification fine-tuning
+  - species classification
+  - transfer learning
+---
+
+# In Construction

--- a/docs/fine_tuning_modules/classification/overview.md
+++ b/docs/fine_tuning_modules/classification/overview.md
@@ -1,5 +1,5 @@
 ---
-description: "PyTorch-Wildlife classification fine-tuning — adapt species classifiers to your own datasets and geographic regions."
+description: "PyTorch-Wildlife classification fine-tuning: adapt species classifiers to your own datasets and geographic regions."
 tags:
   - PyTorch-Wildlife
   - classification fine-tuning

--- a/docs/fine_tuning_modules/detection/overview.md
+++ b/docs/fine_tuning_modules/detection/overview.md
@@ -1,0 +1,10 @@
+---
+description: "PyTorch-Wildlife detection fine-tuning — fine-tune MegaDetector on your own camera-trap data for improved local performance."
+tags:
+  - PyTorch-Wildlife
+  - detection fine-tuning
+  - MegaDetector
+  - transfer learning
+---
+
+# In Construction

--- a/docs/fine_tuning_modules/detection/overview.md
+++ b/docs/fine_tuning_modules/detection/overview.md
@@ -1,5 +1,5 @@
 ---
-description: "PyTorch-Wildlife detection fine-tuning — fine-tune MegaDetector on your own camera-trap data for improved local performance."
+description: "PyTorch-Wildlife detection fine-tuning: fine-tune MegaDetector on your own camera-trap data for improved local performance."
 tags:
   - PyTorch-Wildlife
   - detection fine-tuning

--- a/docs/fine_tuning_modules/overview.md
+++ b/docs/fine_tuning_modules/overview.md
@@ -1,0 +1,10 @@
+---
+description: "PyTorch-Wildlife fine-tuning modules — adapt MegaDetector and classification models to your own camera-trap datasets."
+tags:
+  - PyTorch-Wildlife
+  - fine-tuning
+  - MegaDetector
+  - transfer learning
+---
+
+# In construction

--- a/docs/fine_tuning_modules/overview.md
+++ b/docs/fine_tuning_modules/overview.md
@@ -1,5 +1,5 @@
 ---
-description: "PyTorch-Wildlife fine-tuning modules — adapt MegaDetector and classification models to your own camera-trap datasets."
+description: "PyTorch-Wildlife fine-tuning modules: adapt MegaDetector and classification models to your own camera-trap datasets."
 tags:
   - PyTorch-Wildlife
   - fine-tuning

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,62 @@ nav:
     - Tags: tags.md
   - Cite Us: cite.md
   - Developer Guide: build_mkdocs.md
+  - Reference - Code API:
+      - Base Module:
+        - Overview: base/overview.md
+        - Data:
+          - Datasets: base/data/datasets.md
+          - Transforms: base/data/transforms.md
+        - Models:
+          - Classification:
+              - Base Classifier:
+                  - base/models/classification/base_classifier.md
+              - ResNet Base:
+                  - base/models/classification/resnet_base/base_classifier.md
+                  - base/models/classification/resnet_base/amazon.md
+                  - base/models/classification/resnet_base/custom_weights.md
+                  - base/models/classification/resnet_base/opossum.md
+                  - base/models/classification/resnet_base/serengeti.md
+              - TIMM Base:
+                  - base/models/classification/timm_base/base_classifier.md
+                  - base/models/classification/timm_base/DFNE.md
+                  - base/models/classification/timm_base/Deepfaune.md
+          - Detection:
+              - Base Detector:
+                  - base/models/detection/base_detector.md
+              - HerdNet:
+                  - base/models/detection/herdnet.md
+                  - base/models/detection/herdnet/dla.md
+                  - base/models/detection/herdnet/model.md
+                  - Animaloc:
+                      - Data:
+                          - base/models/detection/herdnet/animaloc/data/patches.md
+                          - base/models/detection/herdnet/animaloc/data/types.md
+                      - Eval:
+                          - base/models/detection/herdnet/animaloc/eval/lmds.md
+                          - base/models/detection/herdnet/animaloc/eval/stitchers.md
+              - Ultralytics Based:
+                  - base/models/detection/ultralytics_based/Deepfaune.md
+                  - MegaDetector v5:
+                      - base/models/detection/ultralytics_based/megadetectorv5.md
+                  - MegaDetector v6:
+                      - base/models/detection/ultralytics_based/megadetectorv6.md
+                      - base/models/detection/ultralytics_based/megadetectorv6_distributed.md
+                  - YOLOv5 Base:
+                      - base/models/detection/ultralytics_based/yolov5_base.md
+                  - YOLOv8 Base:
+                      - base/models/detection/ultralytics_based/yolov8_base.md
+                  - YOLOv8 Distributed:
+                      - base/models/detection/ultralytics_based/yolov8_distributed.md
+        - Utils:
+            - base/utils/misc.md
+            - base/utils/post_process.md
+      - Model Fine-tuning:
+        - Overview: fine_tuning_modules/overview.md
+        - Classification Fine-tuning:
+            - Overview: fine_tuning_modules/classification/overview.md
+        - Detection Fine-tuning:
+            - Overview: fine_tuning_modules/detection/overview.md
 
 markdown_extensions:
   - admonition
@@ -110,3 +166,9 @@ plugins:
       type: date
       enable_creation_date: true
       fallback_to_build_date: true
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google


### PR DESCRIPTION
## What

Migrates the auto-generated **API reference** (mkdocstrings) to PyTorch-Wildlife's own docs site, so the framework's complete code API lives at the framework home rather than on the Biodiversity hub. This is the prerequisite for cleanly removing the leftover package copy from the hub without losing that content from the cluster.

### Changes
- Enable the **mkdocstrings** python handler with `paths: [src]` (this repo uses a src/ layout) + google docstrings.
- Add the **32-page Reference - Code API** nav tree (base module: data / models / utils; plus model fine-tuning), mirroring the structure the hub previously carried.

### Verification
- `mkdocs build` renders the reference from `src/PytorchWildlife` via griffe static analysis (no runtime import / torch needed); the datasets page shows real symbols (`ClassificationImageFolder`, `DetectionImageFolder`).
- Sitemap grew **6 → 40** URLs.
- Em-dash gate clean.

### Stacking
Stacked on the content PR #16 (base `seo/pw-content`; retargets to main when #16 merges). Pairs with the hub removal draft, which depends on this landing first.

Part of resolving the hub/framework duplication (ADO Epic 506340). No reviewer set per current instruction.